### PR TITLE
Pin cloud-volume and numpy to match Boss endpoint.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.18.1
-cloud-volume==5.3.2
+numpy==1.23.4
+cloud-volume==8.26.0
 blosc
 pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
-cloud-volume
+numpy==1.18.1
+cloud-volume==5.3.2
 blosc
 pillow


### PR DESCRIPTION
Use versions currently on Boss endpoint.  We're seeing Numpy problems
with cloud-volume 7.0.